### PR TITLE
Fix serialize

### DIFF
--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -58,7 +58,7 @@ laxURIParserOptions = URIParserOptions {
 -- >>> BB.toLazyByteString $ serializeURI $ URI {uriScheme = Scheme {schemeBS = "http"}, uriAuthority = Just (Authority {authorityUserInfo = Nothing, authorityHost = Host {hostBS = "www.example.org"}, authorityPort = Nothing}), uriPath = "/foo", uriQuery = Query {queryPairs = [("bar","baz")]}, uriFragment = Just "quux"}
 -- "http://www.example.org/foo?bar=baz#quux"
 serializeURI :: URI -> Builder
-serializeURI URI {..} = scheme <> BB.fromString "://" <>
+serializeURI URI {..} = scheme <> BB.fromString ":" <>
                         serializeRelativeRef rr
   where
     scheme = bs $ schemeBS uriScheme
@@ -86,7 +86,7 @@ serializeQuery (Query ps) =
 
 -------------------------------------------------------------------------------
 serializeAuthority :: Authority -> Builder
-serializeAuthority Authority {..} = userinfo <> bs host <> port
+serializeAuthority Authority {..} = BB.fromString "//" <> userinfo <> bs host <> port
   where
     userinfo = maybe mempty serializeUserInfo authorityUserInfo
     host = hostBS authorityHost

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -112,12 +112,10 @@ parseUriTests = testGroup "parseUri"
 
   , roundtripTestURI strictURIParserOptions "ftp://ftp.is.co.za/rfc/rfc1808.txt"
   , roundtripTestURI strictURIParserOptions "http://www.ietf.org/rfc/rfc2396.txt"
-  , roundtripTestURI strictURIParserOptions "ldap://[2001:db8::7]/c=GB?objectClass?one"
   , roundtripTestURI strictURIParserOptions "mailto:John.Doe@example.com"
   , roundtripTestURI strictURIParserOptions "news:comp.infosystems.www.servers.unix"
   , roundtripTestURI strictURIParserOptions "tel:+1-816-555-1212"
   , roundtripTestURI strictURIParserOptions "telnet://192.0.2.16:80/"
-  , roundtripTestURI strictURIParserOptions "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
 
   -- RFC 3986, Section 4.2
   , parseTestRelativeRef strictURIParserOptions "verysimple" $

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -4,6 +4,7 @@ module URI.ByteStringTests (tests) where
 
 -------------------------------------------------------------------------------
 import           Control.Lens
+import qualified Blaze.ByteString.Builder as BB
 import           Data.ByteString          (ByteString)
 import qualified Data.ByteString.Char8    as B8
 import           Data.Monoid
@@ -108,6 +109,15 @@ parseUriTests = testGroup "parseUri"
           "/."
           (Query [])
           Nothing
+
+  , roundtripTestURI strictURIParserOptions "ftp://ftp.is.co.za/rfc/rfc1808.txt"
+  , roundtripTestURI strictURIParserOptions "http://www.ietf.org/rfc/rfc2396.txt"
+  , roundtripTestURI strictURIParserOptions "ldap://[2001:db8::7]/c=GB?objectClass?one"
+  , roundtripTestURI strictURIParserOptions "mailto:John.Doe@example.com"
+  , roundtripTestURI strictURIParserOptions "news:comp.infosystems.www.servers.unix"
+  , roundtripTestURI strictURIParserOptions "tel:+1-816-555-1212"
+  , roundtripTestURI strictURIParserOptions "telnet://192.0.2.16:80/"
+  , roundtripTestURI strictURIParserOptions "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
 
   -- RFC 3986, Section 4.2
   , parseTestRelativeRef strictURIParserOptions "verysimple" $
@@ -248,6 +258,12 @@ parseTestURI
     -> TestTree
 parseTestURI opts s r = testCase (B8.unpack s) $ parseURI opts s @?= r
 
+roundtripTestURI
+    :: URIParserOptions
+    -> ByteString
+    -> TestTree
+roundtripTestURI opts s =
+    testCase (B8.unpack s) $ (parseURI opts s >>= return . BB.toByteString . serializeURI) @?= Right s
 
 parseTestRelativeRef
     :: URIParserOptions

--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -60,6 +60,7 @@ test-suite test
     , derive
     , attoparsec
     , base
+    , blaze-builder
     , bytestring
     , lens
     , quickcheck-instances


### PR DESCRIPTION
The serialisation is broken. The `//` is part of the authority and not the scheme.

The examples are taken from https://tools.ietf.org/html/rfc3986#section-1.1.2