### PR TITLE
Matrix params, query flags, and other changes

### DIFF
--- a/src/URI/ByteString.hs
+++ b/src/URI/ByteString.hs
@@ -30,7 +30,8 @@ module URI.ByteString
     , Port(..)
     , Authority(..)
     , UserInfo(..)
-    , Query(..)
+    , IsQueryPair(..)
+    , IsPathSegment(..)
     , URI(..)
     , RelativeRef(..)
     , SchemaError(..)
@@ -58,8 +59,6 @@ module URI.ByteString
     -- ** Lenses over 'UserInfo'
     , uiUsernameL
     , uiPasswordL
-    -- ** Lenses over 'Query'
-    , queryPairsL
     -- ** Lenses over 'URI'
     , uriSchemeL
     , uriAuthorityL

--- a/src/URI/ByteString/Lens.hs
+++ b/src/URI/ByteString/Lens.hs
@@ -102,20 +102,6 @@ uiPasswordL =
 
 -------------------------------------------------------------------------------
 -- | @
--- queryPairsL :: Lens' 'Query' [('ByteString', 'ByteString')]
--- @
-queryPairsL
-  :: Functor f
-  => ([(ByteString, ByteString)] -> f [(ByteString, ByteString)])
-  -> Query
-  -> f Query
-queryPairsL =
-  lens queryPairs (\a b -> a { queryPairs = b})
-{-# INLINE queryPairsL #-}
-
-
--------------------------------------------------------------------------------
--- | @
 -- uriSchemeL :: Lens' 'URI' 'Scheme'
 -- @
 uriSchemeL :: Functor f => (Scheme -> f Scheme) -> URI -> f URI
@@ -138,23 +124,22 @@ uriAuthorityL =
 
 -------------------------------------------------------------------------------
 -- | @
--- uriPathL :: Lens' 'URI' 'ByteString'
+-- uriPathL :: IsPathSegment a => Lens' 'URI' [a]
 -- @
 uriPathL
-  :: Functor f => (ByteString -> f ByteString) -> URI -> f URI
-uriPathL =
-  lens uriPath (\a b -> a { uriPath = b})
+  :: (Functor f, IsPathSegment a) => ([a] -> f [a]) -> URI -> f URI
+uriPathL = undefined
 {-# INLINE uriPathL #-}
 
 
 -------------------------------------------------------------------------------
 -- | @
--- uriQueryL :: Lens' 'URI' 'Query'
+-- uriQueryL :: IsQueryPair a => Lens' 'URI''[a]
 -- @
-uriQueryL :: Functor f => (Query -> f Query) -> URI -> f URI
-uriQueryL =
-  lens uriQuery (\a b -> a { uriQuery = b})
+uriQueryL :: (Functor f, IsQueryPair a) => ([a] -> f [a]) -> URI -> f URI
+uriQueryL = undefined
 {-# INLINE uriQueryL #-}
+
 
 -------------------------------------------------------------------------------
 -- | @
@@ -182,23 +167,22 @@ rrAuthorityL =
 
 -------------------------------------------------------------------------------
 -- | @
--- rrPathL :: Lens' 'RelativeRef' 'ByteString'
+-- rrPathL :: IsPathSegment a => Lens' 'RelativeRef' [a]
 -- @
 rrPathL
-  :: Functor f => (ByteString -> f ByteString) -> RelativeRef -> f RelativeRef
-rrPathL =
-  lens rrPath (\a b -> a { rrPath = b})
+  :: (Functor f, IsPathSegment a) => ([a] -> f [a]) -> RelativeRef -> f RelativeRef
+rrPathL = undefined
 {-# INLINE rrPathL #-}
 
 
 -------------------------------------------------------------------------------
 -- | @
--- rrQueryL :: Lens' 'RelativeRef' 'Query'
+-- rrQueryL :: IsQueryPair a => Lens' 'RelativeRef' [a]
 -- @
-rrQueryL :: Functor f => (Query -> f Query) -> RelativeRef -> f RelativeRef
-rrQueryL =
-  lens rrQuery (\a b -> a { rrQuery = b})
+rrQueryL :: (Functor f, IsQueryPair a) => ([a] -> f [a]) -> RelativeRef -> f RelativeRef
+rrQueryL = undefined
 {-# INLINE rrQueryL #-}
+
 
 -------------------------------------------------------------------------------
 -- | @


### PR DESCRIPTION
I wrote this as a basis for discussion.  I think I did all the types, but parts of the implementation are missing.

Related to #12, #13.

I am still in favour of something like this:

``` haskell
type URI = URI' p q
data URI' p q = URI' { ... uriPath :: [p] ... uriQuery :: [q] ... }
```

I think this would be an extension of what's already in this pull request.  But if there is no consensus on this I will drop it.

If and when there is agreement on this approach, I will fill in the missing pieces.  If I have missed any of the points already made in the issues, please point me to them, and I'll try again.
