### PR TITLE
Adding functions for direct serialisation to ByteStrings

### DIFF
--- a/src/URI/ByteString.hs
+++ b/src/URI/ByteString.hs
@@ -45,7 +45,9 @@ module URI.ByteString
     , relativeRefParser
     -- * Serializing
     , serializeURI
+    , serializeURI'
     , serializeRelativeRef
+    , serializeRelativeRef'
     -- * Low level utility functions
     , urlDecode
     , urlDecodeQuery

--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -52,8 +52,9 @@ laxURIParserOptions = URIParserOptions {
 -- | URI Serializer
 -------------------------------------------------------------------------------
 
--- | Serialize a URI into a strict ByteString
--- Example:
+-- | Serialize a URI into a Builder.
+--
+-- Example of serializing + converting to a lazy "Data.ByteString.Lazy.ByteString":
 --
 -- >>> BB.toLazyByteString $ serializeURI $ URI {uriScheme = Scheme {schemeBS = "http"}, uriAuthority = Just (Authority {authorityUserInfo = Nothing, authorityHost = Host {hostBS = "www.example.org"}, authorityPort = Nothing}), uriPath = "/foo", uriQuery = Query {queryPairs = [("bar","baz")]}, uriFragment = Just "quux"}
 -- "http://www.example.org/foo?bar=baz#quux"
@@ -63,6 +64,10 @@ serializeURI URI {..} = scheme <> BB.fromString ":" <>
   where
     scheme = bs $ schemeBS uriScheme
     rr = RelativeRef uriAuthority uriPath uriQuery uriFragment
+
+-- | Like 'serializeURI', with conversion into a strict 'ByteString'.
+serializeURI' :: URI -> ByteString
+serializeURI' = BB.toByteString . serializeURI
 
 -- | Like 'serializeURI', but do not render scheme.
 serializeRelativeRef :: RelativeRef -> Builder
@@ -74,6 +79,9 @@ serializeRelativeRef RelativeRef {..} = authority <> path <> query <> fragment
     query = serializeQuery rrQuery
     fragment = maybe mempty (\s -> c8 '#' <> bs s) rrFragment
 
+-- | Like 'serializeRelativeRef', with conversion into a strict 'ByteString'.
+serializeRelativeRef' :: URI -> ByteString
+serializeRelativeRef' = BB.toByteString . serializeURI
 
 -------------------------------------------------------------------------------
 serializeQuery :: Query -> Builder


### PR DESCRIPTION
### Motivation

Since only serialisation functions of the form `URI -> Builder` are exposed, it forces a direct dependency on `blaze-builder` + an extra import just to perform `ByteString -> URI -> ByteString` de/serialisation.

It's irritating to continually depend on `blaze-builder` to just `import Blaze.ByteString.Builder` and use `to{Lazy,}ByteString` to get something that can be used with libraries like `http-client` etc.

### Changes

Adds two additional functions, `serializeURI'` and `serializeRelativeRef'` to convert directly to `Data.ByteString.ByteString`. They both just use the respective existing `serialize*` function, composed with `toByteString` from `blaze-builder`.

Went with the prime suffix since it's commonly used to denote strictness and the only alternatives I could think of were overly verbose, like `serializeURIToBS/ByteString` etc. Open to name bike-shedding.

Also open to creating a PR that completely removes `blaze-builder` in favour of just depending on `Data.ByteString.Builder` if there's no specific reason for the dependency?