### PR TITLE
Introduce URIRef, a GADT that is either a URI or a relative reference

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main (main) where
@@ -16,13 +18,15 @@ import           URI.ByteString
 instance NFData Authority
 instance NFData Host
 instance NFData UserInfo
-instance NFData URI
-instance NFData RelativeRef
 instance NFData SchemaError
 instance NFData URIParseError
 instance NFData Scheme
 instance NFData Port
 instance NFData Query
+
+instance NFData (URIRef a) where
+  rnf (URI a b c d e) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d `seq` rnf e
+  rnf (RelativeRef b c d e) = rnf b `seq` rnf c `seq` rnf d `seq` rnf e
 
 
 -------------------------------------------------------------------------------
@@ -39,8 +43,8 @@ main = defaultMain
       ]
   , bgroup "serializing"
     [
-      bench "URI.ByteString.serializeURI" $ nf (toLazyByteString . serializeURI) exampleURI
-    , bench "URI.ByteString.serializeRelativeRef" $ nf (toLazyByteString . serializeRelativeRef) exampleRelativeRef
+      bench "URI.ByteString.serializeURIRef on URI" $ nf (toLazyByteString . serializeURIRef) exampleURI
+    , bench "URI.ByteString.serializeURIRef on relative ref" $ nf (toLazyByteString . serializeURIRef) exampleRelativeRef
     ]
   ]
 

--- a/src/URI/ByteString.hs
+++ b/src/URI/ByteString.hs
@@ -31,23 +31,24 @@ module URI.ByteString
     , Authority(..)
     , UserInfo(..)
     , Query(..)
-    , URI(..)
-    , RelativeRef(..)
+    , URIRef(..)
+    , Absolute
+    , Relative
     , SchemaError(..)
     , URIParseError(..)
     , URIParserOptions(..)
     , strictURIParserOptions
     , laxURIParserOptions
+    -- * Operations
+    , toAbsolute
     -- * Parsing
     , parseURI
     , parseRelativeRef
     , uriParser
     , relativeRefParser
     -- * Serializing
-    , serializeURI
-    , serializeURI'
-    , serializeRelativeRef
-    , serializeRelativeRef'
+    , serializeURIRef
+    , serializeURIRef'
     -- * Low level utility functions
     , urlDecode
     , urlDecodeQuery
@@ -70,19 +71,29 @@ module URI.ByteString
     , uiPasswordL
     -- ** Lenses over 'Query'
     , queryPairsL
-    -- ** Lenses over 'URI'
+    -- ** Lenses over 'URIRef'
     , uriSchemeL
+    , authorityL
+    , pathL
+    , queryL
+    , fragmentL
+    -- ** Lenses over 'URIParserOptions'
+    , upoValidQueryCharL
+    -- ** Deprecated
+    , URI
+    , RelativeRef
+    , serializeURI
+    , serializeURI'
+    , serializeRelativeRef
+    , serializeRelativeRef'
     , uriAuthorityL
     , uriPathL
     , uriQueryL
     , uriFragmentL
-    -- ** Lenses over 'RelativeRef'
     , rrAuthorityL
     , rrPathL
     , rrQueryL
     , rrFragmentL
-    -- ** Lenses over 'URIParserOptions'
-    , upoValidQueryCharL
     ) where
 
 -------------------------------------------------------------------------------

--- a/src/URI/ByteString/Lens.hs
+++ b/src/URI/ByteString/Lens.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE RecordWildCards #-}
 module URI.ByteString.Lens where
 
 
@@ -84,17 +86,11 @@ queryPairsL =
 
 
 -------------------------------------------------------------------------------
-uriSchemeL :: Lens' URI Scheme
-uriSchemeL =
-  lens uriScheme (\a b -> a { uriScheme = b})
-{-# INLINE uriSchemeL #-}
-
-
--------------------------------------------------------------------------------
 uriAuthorityL :: Lens' URI (Maybe Authority)
 uriAuthorityL =
   lens uriAuthority (\a b -> a { uriAuthority = b})
 {-# INLINE uriAuthorityL #-}
+{-# DEPRECATED uriAuthorityL "Use 'authorityL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -102,6 +98,7 @@ uriPathL :: Lens' URI ByteString
 uriPathL =
   lens uriPath (\a b -> a { uriPath = b})
 {-# INLINE uriPathL #-}
+{-# DEPRECATED uriPathL "Use 'pathL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -109,6 +106,7 @@ uriQueryL :: Lens' URI Query
 uriQueryL =
   lens uriQuery (\a b -> a { uriQuery = b})
 {-# INLINE uriQueryL #-}
+{-# DEPRECATED uriQueryL "Use 'queryL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -116,6 +114,7 @@ uriFragmentL :: Lens' URI (Maybe ByteString)
 uriFragmentL =
   lens uriFragment (\a b -> a { uriFragment = b})
 {-# INLINE uriFragmentL #-}
+{-# DEPRECATED uriFragmentL "Use 'fragmentL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -123,6 +122,7 @@ rrAuthorityL :: Lens' RelativeRef (Maybe Authority)
 rrAuthorityL =
   lens rrAuthority (\a b -> a { rrAuthority = b})
 {-# INLINE rrAuthorityL #-}
+{-# DEPRECATED rrAuthorityL "Use 'authorityL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -130,6 +130,7 @@ rrPathL :: Lens' RelativeRef ByteString
 rrPathL =
   lens rrPath (\a b -> a { rrPath = b})
 {-# INLINE rrPathL #-}
+{-# DEPRECATED rrPathL "Use 'pathL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -137,6 +138,7 @@ rrQueryL :: Lens' RelativeRef Query
 rrQueryL =
   lens rrQuery (\a b -> a { rrQuery = b})
 {-# INLINE rrQueryL #-}
+{-# DEPRECATED rrQueryL "Use 'queryL' instead" #-}
 
 
 -------------------------------------------------------------------------------
@@ -144,6 +146,63 @@ rrFragmentL :: Lens' RelativeRef (Maybe ByteString)
 rrFragmentL =
   lens rrFragment (\a b -> a { rrFragment = b})
 {-# INLINE rrFragmentL #-}
+{-# DEPRECATED rrFragmentL "Use 'fragmentL' instead" #-}
+
+
+-------------------------------------------------------------------------------
+uriSchemeL :: Lens' (URIRef Absolute) Scheme
+uriSchemeL = lens uriScheme setter where
+  setter :: URIRef Absolute  -> Scheme -> URIRef Absolute
+  setter (URI _ b c d e) a' = URI a' b c d e
+{-# INLINE uriSchemeL #-}
+
+
+-------------------------------------------------------------------------------
+authorityL :: Lens' (URIRef a) (Maybe Authority)
+authorityL = lens getter setter where
+  getter :: URIRef a -> Maybe Authority
+  getter (URI {..}) = uriAuthority
+  getter (RelativeRef {..}) = rrAuthority
+  setter :: URIRef a -> Maybe Authority -> URIRef a
+  setter (URI a _ c d e) b' = URI a b' c d e
+  setter (RelativeRef _ c d e) b' = RelativeRef b' c d e
+{-# INLINE authorityL #-}
+
+
+-------------------------------------------------------------------------------
+pathL :: Lens' (URIRef a) ByteString
+pathL = lens getter setter where
+  getter :: URIRef a -> ByteString
+  getter (URI {..}) = uriPath
+  getter (RelativeRef {..}) = rrPath
+  setter :: URIRef a -> ByteString -> URIRef a
+  setter (URI a b _ d e) c' = URI a b c' d e
+  setter (RelativeRef b _ d e) c' = RelativeRef b c' d e
+{-# INLINE pathL #-}
+
+
+-------------------------------------------------------------------------------
+queryL :: Lens' (URIRef a) Query
+queryL = lens getter setter where
+  getter :: URIRef a -> Query
+  getter (URI {..}) = uriQuery
+  getter (RelativeRef {..}) = rrQuery
+  setter :: URIRef a -> Query -> URIRef a
+  setter (URI a b c _ e) d' = URI a b c d' e
+  setter (RelativeRef b c _ e) d' = RelativeRef b c d' e
+{-# INLINE queryL #-}
+
+
+-------------------------------------------------------------------------------
+fragmentL :: Lens' (URIRef a) (Maybe ByteString)
+fragmentL = lens getter setter where
+  getter :: URIRef a -> Maybe ByteString
+  getter (URI {..}) = uriFragment
+  getter (RelativeRef {..}) = rrFragment
+  setter :: URIRef a -> Maybe ByteString -> URIRef a
+  setter (URI a b c d _) e' = URI a b c d e'
+  setter (RelativeRef b c d _) e' = RelativeRef b c d e'
+{-# INLINE fragmentL #-}
 
 
 -------------------------------------------------------------------------------

--- a/src/URI/ByteString/Types.hs
+++ b/src/URI/ByteString/Types.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 module URI.ByteString.Types where
 
 -------------------------------------------------------------------------------
@@ -53,24 +56,43 @@ newtype Query = Query { queryPairs :: [(ByteString, ByteString)] }
 
 
 -------------------------------------------------------------------------------
-data URI = URI {
-      uriScheme    :: Scheme
-    , uriAuthority :: Maybe Authority
-    , uriPath      :: ByteString
-    , uriQuery     :: Query
-    , uriFragment  :: Maybe ByteString
-    -- ^ URI fragment. Does not include the #
-    } deriving (Show, Eq, Generic, Typeable, Ord)
+-- | Note: URI fragment does not include the #
+data URIRef a where
+  URI :: { uriScheme :: Scheme
+         , uriAuthority :: Maybe Authority
+         , uriPath :: ByteString
+         , uriQuery :: Query
+         , uriFragment :: Maybe ByteString
+         } -> URIRef Absolute
+  RelativeRef :: { rrAuthority :: Maybe Authority
+                 , rrPath :: ByteString
+                 , rrQuery :: Query
+                 , rrFragment :: Maybe ByteString
+                 } -> URIRef Relative
+
+deriving instance Show (URIRef a)
+deriving instance Eq (URIRef a)
+-- deriving instance Generic (URIRef a)
+deriving instance Ord (URIRef a)
+
+#ifdef WITH_TYPEABLE
+deriving instance Typeable URIRef
+#endif
+
+-------------------------------------------------------------------------------
+data Absolute deriving(Typeable)
 
 
 -------------------------------------------------------------------------------
-data RelativeRef = RelativeRef {
-      rrAuthority :: Maybe Authority
-    , rrPath      :: ByteString
-    , rrQuery     :: Query
-    , rrFragment  :: Maybe ByteString
-    -- ^ URI fragment. Does not include the #
-    } deriving (Show, Eq, Generic, Typeable, Ord)
+data Relative deriving(Typeable)
+
+
+-------------------------------------------------------------------------------
+type URI = URIRef Absolute
+
+
+-------------------------------------------------------------------------------
+type RelativeRef = URIRef Relative
 
 
 -------------------------------------------------------------------------------

--- a/test/URI/ByteString/Arbitrary.hs
+++ b/test/URI/ByteString/Arbitrary.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module URI.ByteString.Arbitrary where
 
@@ -35,7 +36,7 @@ instance Arbitrary Port where
   arbitrary = Port <$> arbitrary
 
 
-instance Arbitrary URI where
+instance Arbitrary (URIRef Absolute) where
   arbitrary = URI <$> arbitrary
                   <*> arbitrary
                   <*> arbitrary
@@ -43,7 +44,7 @@ instance Arbitrary URI where
                   <*> arbitrary
 
 
-instance Arbitrary RelativeRef where
+instance Arbitrary (URIRef Relative) where
   arbitrary = RelativeRef <$> arbitrary
                           <*> arbitrary
                           <*> arbitrary

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module URI.ByteStringTests (tests) where
@@ -206,31 +207,31 @@ lensTests = testGroup "lenses"
   , testProperty "uriSchemeL Lens" $ \uri x ->
      (uri ^. uriSchemeL === uriScheme uri) .&&.
      ((uri & uriSchemeL .~ x) === uri { uriScheme = x })
-  , testProperty "uriAuthorityL Lens" $ \uri x ->
-     (uri ^. uriAuthorityL === uriAuthority uri) .&&.
-     ((uri & uriAuthorityL .~ x) === uri { uriAuthority = x })
-  , testProperty "uriPathL Lens" $ \uri x ->
-     (uri ^. uriPathL === uriPath uri) .&&.
-     ((uri & uriPathL .~ x) === uri { uriPath = x })
-  , testProperty "uriQueryL Lens" $ \uri x ->
-     (uri ^. uriQueryL === uriQuery uri) .&&.
-     ((uri & uriQueryL .~ x) === uri { uriQuery = x })
-  , testProperty "uriFragmentL Lens" $ \uri x ->
-     (uri ^. uriFragmentL === uriFragment uri) .&&.
-     ((uri & uriFragmentL .~ x) === uri { uriFragment = x })
+  , testProperty "authorityL Lens on URI" $ \uri x ->
+     (uri ^. authorityL === uriAuthority uri) .&&.
+     ((uri & authorityL .~ x) === uri { uriAuthority = x })
+  , testProperty "pathL Lens on URI" $ \uri x ->
+     (uri ^. pathL === uriPath uri) .&&.
+     ((uri & pathL .~ x) === uri { uriPath = x })
+  , testProperty "queryL Lens on URI" $ \uri x ->
+     (uri ^. queryL === uriQuery uri) .&&.
+     ((uri & queryL .~ x) === uri { uriQuery = x })
+  , testProperty "fragmentL Lens on URI" $ \uri x ->
+     (uri ^. fragmentL === uriFragment uri) .&&.
+     ((uri & fragmentL .~ x) === uri { uriFragment = x })
 
-  , testProperty "rrAuthorityL Lens" $ \rr x ->
-     (rr ^. rrAuthorityL === rrAuthority rr) .&&.
-     ((rr & rrAuthorityL .~ x) === rr { rrAuthority = x })
-  , testProperty "rrPathL Lens" $ \rr x ->
-     (rr ^. rrPathL === rrPath rr) .&&.
-     ((rr & rrPathL .~ x) === rr { rrPath = x })
-  , testProperty "rrQueryL Lens" $ \rr x ->
-     (rr ^. rrQueryL === rrQuery rr) .&&.
-     ((rr & rrQueryL .~ x) === rr { rrQuery = x })
-  , testProperty "rrFragmentL Lens" $ \rr x ->
-     (rr ^. rrFragmentL === rrFragment rr) .&&.
-     ((rr & rrFragmentL .~ x) === rr { rrFragment = x })
+  , testProperty "authorityL Lens on relative ref" $ \rr x ->
+     (rr ^. authorityL === rrAuthority rr) .&&.
+     ((rr & authorityL .~ x) === rr { rrAuthority = x })
+  , testProperty "pathL Lens on relative ref" $ \rr x ->
+     (rr ^. pathL === rrPath rr) .&&.
+     ((rr & pathL .~ x) === rr { rrPath = x })
+  , testProperty "queryL Lens on relative ref" $ \rr x ->
+     (rr ^. queryL === rrQuery rr) .&&.
+     ((rr & queryL .~ x) === rr { rrQuery = x })
+  , testProperty "fragmentL Lens on relative ref" $ \rr x ->
+     (rr ^. fragmentL === rrFragment rr) .&&.
+     ((rr & fragmentL .~ x) === rr { rrFragment = x })
   ]
 
 
@@ -296,7 +297,7 @@ roundtripTestURI
     -> ByteString
     -> TestTree
 roundtripTestURI opts s =
-    testCase (B8.unpack s) $ (parseURI opts s >>= return . BB.toByteString . serializeURI) @?= Right s
+    testCase (B8.unpack s) $ (parseURI opts s >>= return . serializeURIRef') @?= Right s
 
 
 -------------------------------------------------------------------------------
@@ -311,7 +312,7 @@ parseTestRelativeRef opts s r =
 
 -------------------------------------------------------------------------------
 serializeURITests :: TestTree
-serializeURITests = testGroup "serializeURI"
+serializeURITests = testGroup "serializeURIRef"
   [
     testCase "renders userinfo correctly" $ do
        let ui = UserInfo "user" "pass"
@@ -320,7 +321,7 @@ serializeURITests = testGroup "serializeURI"
                  "/"
                  (Query [("foo", "bar")])
                  (Just "somefragment")
-       let res = BB.toLazyByteString (serializeURI uri)
+       let res = BB.toLazyByteString (serializeURIRef uri)
        res @?= "http://user:pass@www.example.org/?foo=bar#somefragment"
   , testCase "encodes decoded paths" $ do
        let uri = URI (Scheme "http")
@@ -328,6 +329,6 @@ serializeURITests = testGroup "serializeURI"
                  "/weird path"
                  (Query [])
                  Nothing
-       let res = BB.toLazyByteString (serializeURI uri)
+       let res = BB.toLazyByteString (serializeURIRef uri)
        res @?= "http://www.example.org/weird%20path"
   ]

--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -44,6 +44,9 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
+  if impl(ghc >= 7.8)
+    cpp-options: -DWITH_TYPEABLE
+
   if flag(lib-Werror)
     ghc-options: -Werror
 


### PR DESCRIPTION
This is a draft attempt to implement #23, inspired from what was done in the [path][1] package.
I've tried to alter the API as little as possible. The only regression is the missing `Generic` instance for `URIRef a`, as [it cannot be derived from a GADT][2], but I guess we could handwrite it.

[1]: https://hackage.haskell.org/package/path/docs/Path.html
[2]: https://wiki.haskell.org/GHC.Generics