### PR TITLE
Allow empty fragment

### DIFF
--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -620,13 +620,13 @@ validForQueryLax = notInClass "&#"
 -------------------------------------------------------------------------------
 -- | Only parses a fragment if the # signifiier is there
 mFragmentParser :: URIParser (Maybe ByteString)
-mFragmentParser = word8' hash `thenJust` fragmentParser
+mFragmentParser = mParse $ word8' hash *> fragmentParser
 
 
 -------------------------------------------------------------------------------
 -- | The final piece of a uri, e.g. #fragment, minus the #.
 fragmentParser :: URIParser ByteString
-fragmentParser = A.takeWhile1 validFragmentWord `orFailWith` MalformedFragment
+fragmentParser = Parser' $ A.takeWhile validFragmentWord
   where
     validFragmentWord = inClass ('?':'/':pchar)
 

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -91,6 +91,12 @@ parseUriTests = testGroup "parseUri"
           "/foo"
           mempty
           (Just "bar")
+  , testParses "http://www.example.org/foo#" $
+      URI (Scheme "http")
+          (Just (Authority Nothing (Host "www.example.org") Nothing))
+          "/foo"
+          mempty
+          (Just "")
   , testParseFailure "http://www.example.org/foo#bar#baz" MalformedFragment
   , testParseFailure "https://www.example.org?listParam[]=foo,bar" MalformedQuery
   , testParsesLax "https://www.example.org?listParam[]=foo,bar" $


### PR DESCRIPTION
Here's a quick branch for empty fragment identifiers.

Changes

- Add a test for empty fragments. See the first commit. In fact, git-checkout that one and `cabal test` it. It curiously fails with `MalformedQuery` rather than `MalformedFragment`. Ref. the spec, but in my opinion, the only `MalformedFragment` has invalid chars:

  > A fragment identifier component is indicated by the presence of a number sign ("#") character and terminated by the end of the URI.
  >
  >       fragment    = *( pchar / "/" / "?" )

  Two mildly different statements, but I'll trust the latter.

- Modify `mFragmentParser` and `fragmentParser` to allow zero-length fragments. The test from the earlier commit PASSes, as do the others.

Sorry for burying this in the unparsed query string request, which will be heavily revised...