### PR TITLE
Suggestion for the FIXME note on bsToNum.

### DIFF
--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -36,7 +36,7 @@ library
 
   build-depends:
 
-      attoparsec       >= 0.10    && < 0.14
+      attoparsec       >= 0.12    && < 0.14
     , base             >= 4.6     && < 4.10
     , bytestring       >= 0.9.1   && < 0.11
     , blaze-builder    >= 0.3.0.0 && < 0.5


### PR DESCRIPTION
I used attoparsec's decimal parser to eliminate the `bsToNum` function.

Good:
 - eliminates a FIXME
 - probably faster than `takeWhile isDigit` ... `bsToNum`

Bad:
 - needs attoparsec-0.12.0.0

Here's a nugget: I wrote a test for `http://192.168.1.300/` -> `MalformedHost` and it turns out that it's OK. In fact, it looks like any combination of digits and dots is technically OK in the spec. I like how the code mirrors the spec, but it turns out that the spec is a little over-defined. The only true need for `ipV4Parser` is if some metadata is retained about the type of hostname encountered. Maybe more constructors for `Host`.

I'm perfectly happy with `Host`, `ipV4Parser` and even `bsToNum` the way they are. I just thought I'd address the FIXME note.
