### PR TITLE
Allow base 4.10

### DIFF
--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -16,6 +16,7 @@ bug-reports:         https://github.com/Soostone/uri-bytestring/issues
 Tested-With:         GHC == 7.6.3
                    , GHC == 7.8.4
                    , GHC == 7.10.1
+                   , GHC == 8.0.2
 extra-source-files:
   README.md
   CONTRIBUTING.md

--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -39,7 +39,7 @@ library
   build-depends:
 
       attoparsec       >= 0.12    && < 0.14
-    , base             >= 4.6     && < 4.10
+    , base             >= 4.6     && < 5
     , bytestring       >= 0.9.1   && < 0.11
     , blaze-builder    >= 0.3.0.0 && < 0.5
     , template-haskell >= 2.9     && < 2.12


### PR DESCRIPTION
There are no breaking changes in version 4.10 of `base`. I'm enabling testing with the second release candidate of GHC 8.2.1 on CI, and in a couple of places the only package that breaks my builds is `uri-bytestring`.

Please kindly either relax the constraint by publishing a revision on Hackage or release a new version after merging this PR.