### PR TITLE
Make buildable with GHC-8.2.1-rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Use new container infrastructure to enable caching
 sudo: false
+dist: trusty
 
 # Choose a lightweight base image; we provide our own build tools.
 language: c
@@ -16,6 +17,7 @@ matrix:
   include:
     - env: ARGS="--stack-yaml=stack-lts-2.yaml"
     - env: ARGS="--stack-yaml=stack-lts-3.yaml"
+    - env: ARGS="--stack-yaml=stack-ghc-8.2.1.yaml"
     - env: ARGS="--resolver=lts-4"
     - env: ARGS="--resolver=lts-5"
     - env: ARGS="--resolver=lts-6"

--- a/stack-ghc-8.2.1.yaml
+++ b/stack-ghc-8.2.1.yaml
@@ -1,0 +1,85 @@
+resolver: ghc-8.2.0.20170507
+compiler: ghc-8.2.0.20170507
+compiler-check: match-exact
+setup-info:
+ ghc:
+  linux64:
+   8.2.0.20170507:
+    url: https://downloads.haskell.org/~ghc/8.2.1-rc2/ghc-8.2.0.20170507-x86_64-deb8-linux.tar.xz
+  macosx:
+   8.2.0.20170507:
+    url: https://downloads.haskell.org/~ghc/8.2.1-rc2/ghc-8.2.0.20170507-x86_64-apple-darwin.tar.xz
+  windows64:
+   8.2.0.20170507:
+    url: https://downloads.haskell.org/~ghc/8.2.1-rc2/ghc-8.2.0.20170507-x86_64-unknown-mingw32.tar.xz
+extra-deps:
+- abstract-deque-0.3
+- abstract-par-0.3.3
+- aeson-1.2.0.0
+- ansi-terminal-0.6.3.1
+- ansi-wl-pprint-0.6.7.3
+- async-2.1.1.1
+- attoparsec-0.13.1.0
+- base-compat-0.9.3
+- base-orphans-0.6
+- blaze-builder-0.4.0.2
+- call-stack-0.1.0
+- case-insensitive-1.2.0.10
+- cassava-0.4.5.1
+- cereal-0.5.4.0
+- clock-0.7.2
+- code-page-0.1.3
+- criterion-1.2.0.0
+- deepseq-generics-0.2.0.0
+- dlist-0.8.0.2
+- erf-2.0.0.0
+- exceptions-0.8.3
+- generics-sop-0.3.0.0
+- Glob-0.8.0
+- hashable-1.2.6.0
+- HUnit-1.6.0.0
+- integer-logarithms-1.0.1
+- js-flot-0.8.3
+- js-jquery-3.2.1
+- math-functions-0.2.1.0
+- microstache-1
+- monad-par-0.3.4.8
+- monad-par-extras-0.3.3
+- mtl-2.2.1
+- mwc-random-0.13.6.0
+- network-uri-2.6.1.0
+- old-locale-1.0.0.7
+- old-time-1.1.0.3
+- optparse-applicative-0.13.2.0
+- parallel-3.2.1.1
+- parsec-3.1.11
+- primitive-0.6.2.0
+- QuickCheck-2.9.2
+- quickcheck-instances-0.3.13
+- random-1.1
+- regex-base-0.93.2
+- regex-tdfa-1.2.2
+- scientific-0.3.4.13
+- semigroups-0.18.3
+- statistics-0.14.0.2
+- stm-2.4.4.1
+- tagged-0.8.5
+- tasty-0.11.2.1
+- tasty-hunit-0.9.2
+- tasty-quickcheck-0.8.4
+- text-1.2.2.2
+- tf-random-0.5
+- th-lift-0.7.7
+- th-lift-instances-0.1.11
+- time-locale-compat-0.1.1.3
+- transformers-compat-0.5.1.4
+- unbounded-delays-0.1.1.0
+- unordered-containers-0.2.8.0
+- uuid-types-1.0.3
+- vector-0.12.0.1
+- vector-algorithms-0.7.0.1
+- vector-binary-instances-0.2.3.5
+- vector-th-unbox-0.2.1.6
+flags:
+  time-locale-compat:
+    old-locale: false

--- a/stack-lts-2.yaml
+++ b/stack-lts-2.yaml
@@ -2,8 +2,7 @@ resolver: lts-2.12
 packages:
   - '.'
 extra-deps:
-  - lens-simple-0.1.0.8
-  - lens-family-1.2.0
+  - base-compat-0.9.3
   - generics-sop-0.2.2.0
   - th-lift-instances-0.1.11
   - th-lift-0.7.6

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -4,13 +4,15 @@
 module URI.ByteStringTests (tests) where
 
 -------------------------------------------------------------------------------
+import           Control.Applicative      (Const (..))
 import qualified Blaze.ByteString.Builder as BB
 import           Data.ByteString          (ByteString)
 import qualified Data.ByteString.Char8    as B8
 import           Data.Either
+import           Data.Function.Compat     ((&))
+import           Data.Functor.Identity    (Identity (..))
 import qualified Data.Map.Strict          as M
 import           Data.Monoid
-import           Lens.Simple
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
@@ -21,6 +23,15 @@ import           URI.ByteString
 import           URI.ByteString.Arbitrary ()
 -------------------------------------------------------------------------------
 import           URI.ByteStringQQTests    ()
+
+infixr 4 .~
+(.~) :: ((a -> Identity b) -> s -> Identity t) -> b -> s -> t
+(.~) l b s = runIdentity (l (const (Identity b)) s)
+
+infixl ^.
+(^.) :: s -> ((a -> Const a a) -> s -> Const a s) -> a
+s ^. l = getConst (l Const s)
+
 
 tests :: TestTree
 tests = testGroup "URI.Bytestring"

--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -17,6 +17,7 @@ Tested-With:         GHC == 7.6.3
                    , GHC == 7.8.4
                    , GHC == 7.10.1
                    , GHC == 8.0.2
+                   , GHC == 8.2.1
 extra-source-files:
   README.md
   CONTRIBUTING.md
@@ -42,7 +43,7 @@ library
     , base             >= 4.6     && < 5
     , bytestring       >= 0.9.1   && < 0.11
     , blaze-builder    >= 0.3.0.0 && < 0.5
-    , template-haskell >= 2.9     && < 2.12
+    , template-haskell >= 2.9     && < 2.13
     , th-lift-instances >= 0.1.8  && < 0.2
     , containers
 
@@ -79,11 +80,12 @@ test-suite test
     , tasty-quickcheck
     , attoparsec
     , base
+    , base-compat >= 0.7.0
     , blaze-builder
     , bytestring
-    , lens-simple
     , quickcheck-instances
     , semigroups
+    , transformers
     , containers
     , generics-sop >= 0.2
   default-language:    Haskell2010


### PR DESCRIPTION
- I dropped the dependency on `lens-simple` (it isn't GHC-8.2) ready
    - first I thought it would be easier to depend on `lens` (because it's greatly maintained lib, and in tests dependencies doesn't matter);
    - but then, you only need two non-`base` operators.
- Added `stack-ghc-8.2.1.yaml` using GHC-8.2.1-rc2 so that configuration is actually tested.