### PR TITLE
Conditionally export arbitrary instances (v1)

### DIFF
--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -28,6 +28,10 @@ flag lib-Werror
   default: False
   manual: True
 
+flag export-arbitrary
+  default: False
+  manual: True
+
 library
   exposed-modules:
     URI.ByteString
@@ -38,7 +42,6 @@ library
     URI.ByteString.Internal
 
   build-depends:
-
       attoparsec       >= 0.13.1.0 && < 0.14
     , base             >= 4.6     && < 5
     , bytestring       >= 0.9.1   && < 0.11
@@ -63,20 +66,27 @@ library
   if flag(lib-Werror)
     ghc-options: -Werror
 
+  if flag(export-arbitrary)
+    hs-source-dirs: test
+    exposed-modules:
+      URI.ByteString.Arbitrary
+    build-depends:
+        QuickCheck
+      , quickcheck-instances
+      , generics-sop >= 0.2
+
   ghc-options: -Wall
 
 test-suite test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-    URI.ByteString.Arbitrary
     URI.ByteStringTests
     URI.ByteStringQQTests
   hs-source-dirs: test
   build-depends:
       uri-bytestring
     , HUnit
-    , QuickCheck
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -85,15 +95,21 @@ test-suite test
     , base-compat >= 0.7.0
     , blaze-builder
     , bytestring
-    , quickcheck-instances
     , semigroups
     , transformers
     , containers
-    , generics-sop >= 0.2
   default-language:    Haskell2010
 
   if flag(lib-Werror)
     ghc-options: -Werror
+
+  if !flag(export-arbitrary)
+    other-modules:
+      URI.ByteString.Arbitrary
+    build-depends:
+        QuickCheck
+      , quickcheck-instances
+      , generics-sop >= 0.2
 
   ghc-options: -Wall
 

--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -81,12 +81,14 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+    URI.ByteString.Arbitrary
     URI.ByteStringTests
     URI.ByteStringQQTests
   hs-source-dirs: test
   build-depends:
       uri-bytestring
     , HUnit
+    , QuickCheck
     , tasty
     , tasty-hunit
     , tasty-quickcheck
@@ -95,21 +97,15 @@ test-suite test
     , base-compat >= 0.7.0
     , blaze-builder
     , bytestring
+    , quickcheck-instances
     , semigroups
     , transformers
     , containers
+    , generics-sop >= 0.2
   default-language:    Haskell2010
 
   if flag(lib-Werror)
     ghc-options: -Werror
-
-  if !flag(export-arbitrary)
-    other-modules:
-      URI.ByteString.Arbitrary
-    build-depends:
-        QuickCheck
-      , quickcheck-instances
-      , generics-sop >= 0.2
 
   ghc-options: -Wall
 


### PR DESCRIPTION
Evidence that this is ok:

```sh
stack test --flag uri-bytestring:-export-arbitrary
stack test --flag uri-bytestring:export-arbitrary
```

[The first attempt](https://github.com/Soostone/uri-bytestring/commit/d62a5e961cb033eb4dda77384054f468387fc8a4) failed:

```
<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: URI.ByteString.Arbitrary
```

[Allowing for redundancy in the test target](https://github.com/Soostone/uri-bytestring/commit/0b252cea072c06eaf6643dc6936734a61bc05d8b) helps:

```
[...]
All 95 tests passed (3.08s)

uri-bytestring-0.3.2.0: Test suite test passed
Completed 2 action(s).
```

I also took a package that depends on uri-bytestring and tweaked stack.yaml such that it pulled this branch and set the flag to True, with the desired effect.

I'm not sure how I want to use this in everyday life.  How do I set different flags based on whether I'm running the test suite or in production?  (How do I do that in stack?  How in cabal?)

I tried this:

```
echo 'module Test where import URI.ByteString.Arbitrary ()' > Test.hs
stack exec --flag uri-bytestring:export-arbitrary -- ghc --make Test.hs
```

which fails because the `exec` sub-command does not want me to change configuration.  Then I ran out of ideas.
