### PR TITLE
Fix type errors, try to maintain backwards compat.

### DIFF
--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -89,7 +89,7 @@ test-suite test
     , semigroups
     , transformers
     , containers
-    , generics-sop >= 0.3 && < 0.5
+    , generics-sop >= 0.2 && < 0.5
   default-language:    Haskell2010
 
   if flag(lib-Werror)

--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -1,5 +1,5 @@
 name:                uri-bytestring
-version:             0.3.2.1
+version:             0.3.2.2
 synopsis:            Haskell URI parsing as ByteStrings
 description: uri-bytestring aims to be an RFC3986 compliant URI parser that uses efficient ByteStrings for parsing and representing the URI data.
 license:             BSD3
@@ -89,7 +89,7 @@ test-suite test
     , semigroups
     , transformers
     , containers
-    , generics-sop >= 0.2
+    , generics-sop >= 0.3 && < 0.5
   default-language:    Haskell2010
 
   if flag(lib-Werror)


### PR DESCRIPTION
`generics-sop >= 0.4` will only build with `GHC >8`, I'm not sure how important that constraint is to this package but I've tried to preserve with some CPP guards to use the correct constraints.

Fixes #50 

The CPP around the import is to avoid warnings of redundant imports when it is not needed.