### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -85,10 +85,13 @@ test-suite test
     , base-compat >= 0.7.0
     , blaze-builder
     , bytestring
-    , semigroups
     , transformers
     , containers
     , safe
+
+  if !impl(ghc >= 8)
+    build-depends: semigroups
+
   default-language:    Haskell2010
 
   if flag(lib-Werror)


### PR DESCRIPTION
They are not needed on newer GHC.