### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/uri-bytestring.cabal
+++ b/uri-bytestring.cabal
@@ -10,7 +10,7 @@ maintainer:          Michael Xavier <michael.xavier@soostone.com>
 copyright:           Soostone Inc.
 category:            Web
 build-type:          Simple
-cabal-version:       >=1.16
+cabal-version:       1.16
 homepage:            https://github.com/Soostone/uri-bytestring
 bug-reports:         https://github.com/Soostone/uri-bytestring/issues
 Tested-With:         GHC == 7.8.4


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: uri-bytestring.cabal:13:28: Packages with 'cabal-version: 1.12' or
later should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.16'.
```