### PR TITLE
Be more spec conformant

### DIFF
--- a/src/URI/ByteString.hs
+++ b/src/URI/ByteString.hs
@@ -70,8 +70,6 @@ module URI.ByteString
     normalizeURIRef',
 
     -- * Low level utility functions
-    urlDecode,
-    urlDecodeQuery,
     urlEncodeQuery,
     urlEncodePath,
     urlEncode,

--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -356,11 +356,11 @@ c8 = BB.fromChar
 -- >>> parseURI myLaxOptions "http://www.example.org/foo?bar[]=baz"
 -- Right (URI {uriScheme = Scheme {schemeBS = "http"}, uriAuthority = Just (Authority {authorityUserInfo = Nothing, authorityHost = Host {hostBS = "www.example.org"}, authorityPort = Nothing}), uriPath = "/foo", uriQuery = Query {queryPairs = [("bar[]","baz")]}, uriFragment = Nothing})
 parseURI :: URIParserOptions -> ByteString -> Either URIParseError (URIRef Absolute)
-parseURI opts = parseOnly' OtherError (uriParser' opts)
+parseURI opts = parseOnly' OtherError (uriParser' opts <* Parser' endOfInput)
 
 -- | Like 'parseURI', but do not parse scheme.
 parseRelativeRef :: URIParserOptions -> ByteString -> Either URIParseError (URIRef Relative)
-parseRelativeRef opts = parseOnly' OtherError (relativeRefParser' opts)
+parseRelativeRef opts = parseOnly' OtherError (relativeRefParser' opts <* Parser' endOfInput)
 
 -------------------------------------------------------------------------------
 
@@ -370,6 +370,8 @@ type URIParser = Parser' URIParseError
 -------------------------------------------------------------------------------
 
 -- | Underlying attoparsec parser. Useful for composing with your own parsers.
+--
+-- May not consume all input. You may want to combine it with @endOfInput@.
 uriParser :: URIParserOptions -> Parser (URIRef Absolute)
 uriParser = unParser' . uriParser'
 
@@ -383,14 +385,13 @@ uriParser' opts = do
   (authority, path) <- hierPartParser
   query <- queryParser opts
   frag <- mFragmentParser
-  case frag of
-    Just _ -> endOfInput `orFailWith` MalformedFragment
-    Nothing -> endOfInput `orFailWith` MalformedQuery
   return $ URI scheme authority path query frag
 
 -------------------------------------------------------------------------------
 
 -- | Underlying attoparsec parser. Useful for composing with your own parsers.
+--
+-- May not consume all input. You may want to combine it with @endOfInput@.
 relativeRefParser :: URIParserOptions -> Parser (URIRef Relative)
 relativeRefParser = unParser' . relativeRefParser'
 
@@ -402,9 +403,6 @@ relativeRefParser' opts = do
   (authority, path) <- relativePartParser
   query <- queryParser opts
   frag <- mFragmentParser
-  case frag of
-    Just _ -> endOfInput `orFailWith` MalformedFragment
-    Nothing -> endOfInput `orFailWith` MalformedQuery
   return $ RelativeRef authority path query frag
 
 -------------------------------------------------------------------------------
@@ -619,7 +617,7 @@ queryParser opts = do
     Just c
       | c == question -> skip' 1 *> itemsParser
       | c == hash -> pure mempty
-      | otherwise -> fail' MalformedPath
+      | otherwise -> pure mempty
     _ -> pure mempty
   where
     itemsParser = Query . filter neQuery <$> A.sepBy' (queryItemParser opts) (word8' ampersand)

--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
 
 module URI.ByteString.Internal where
 
@@ -49,7 +50,7 @@ import URI.ByteString.Types
 strictURIParserOptions :: URIParserOptions
 strictURIParserOptions =
   URIParserOptions
-    { upoValidQueryChar = validForQuery
+    { upoLaxQueryParsing = False
     }
 
 -------------------------------------------------------------------------------
@@ -61,7 +62,7 @@ strictURIParserOptions =
 laxURIParserOptions :: URIParserOptions
 laxURIParserOptions =
   URIParserOptions
-    { upoValidQueryChar = validForQueryLax
+    { upoLaxQueryParsing = True
     }
 
 -------------------------------------------------------------------------------
@@ -422,7 +423,6 @@ schemeParser = do
 -- | Corresponds to 'hier-part' in RFC 3986 section 3.
 hierPartParser :: URIParser (Maybe Authority, ByteString)
 hierPartParser =
-  (fmap . fmap) urlDecode' $
   authWithPathParser
     <|> ((Nothing,) <$> pathAbsoluteParser `orFailWith` MalformedPath)
     <|> ((Nothing,) <$> pathRootlessParser `orFailWith` MalformedPath)
@@ -433,7 +433,6 @@ hierPartParser =
 -- | Corresponds to 'relative-part' in RFC 3986 section 4.2.
 relativePartParser :: URIParser (Maybe Authority, ByteString)
 relativePartParser =
-  (fmap . fmap) urlDecode' $
   authWithPathParser
     <|> ((Nothing,) <$> pathAbsoluteParser `orFailWith` MalformedPath)
     <|> ((Nothing,) <$> pathNoSchemeParser `orFailWith` MalformedPath)
@@ -475,11 +474,7 @@ pathRootlessParser = sequenceM [segmentNZParser, pathAbEmptyParser]
 -- | See the "path-empty" grammar in the RFC. Must not be followed
 -- with a path-valid char.
 pathEmptyParser :: Parser ByteString
-pathEmptyParser = do
-  nextChar <- peekWord8
-  case nextChar of
-    Just c -> guard (notInClass pchar c) >> return mempty
-    _ -> return mempty
+pathEmptyParser = (const BS.empty <$> pcharNotParser) <|> (const BS.empty <$> endOfInput)
 
 -------------------------------------------------------------------------------
 
@@ -497,11 +492,12 @@ userInfoParser = (uiTokenParser <* word8 atSym) `orFailWith` MalformedUserInfo
   where
     atSym = 64
     uiTokenParser = do
-      ui <- A.takeWhile1 validForUserInfo
-      let (user, passWithColon) = BS.break (== colon) $ urlDecode' ui
-      let pass = BS.drop 1 passWithColon
+      user <- manyC (pctEncodedParser <|> satisfyClass (subDelims ++ unreserved))
+      pass <- passParser <|> pure BS.empty
       return $ UserInfo user pass
-    validForUserInfo = inClass $ pctEncoded ++ subDelims ++ (':' : unreserved)
+    passParser = do
+      _ <- string ":"
+      manyC (pctEncodedParser <|> satisfyClass (subDelims ++ ":" ++ unreserved))
 
 -------------------------------------------------------------------------------
 
@@ -580,9 +576,7 @@ ipV4Parser =
 
 -- | This corresponds to the hostname, e.g. www.example.org
 regNameParser :: Parser ByteString
-regNameParser = urlDecode' <$> A.takeWhile1 (inClass validForRegName)
-  where
-    validForRegName = pctEncoded ++ subDelims ++ unreserved
+regNameParser = many1C (pctEncodedParser <|> satisfyClass (subDelims <> unreserved))
 
 -------------------------------------------------------------------------------
 
@@ -602,13 +596,13 @@ portParser = (Port <$> A.decimal) `orFailWith` MalformedPort
 
 
 segmentParser :: Parser ByteString
-segmentParser = A.takeWhile (inClass pchar)
+segmentParser = manyC pcharParser
 
 segmentNZParser :: Parser ByteString
-segmentNZParser = A.takeWhile1 (inClass pchar)
+segmentNZParser = many1C pcharParser
 
 segmentNZNCParser :: Parser ByteString
-segmentNZNCParser = A.takeWhile1 (inClass $ pctEncoded ++ subDelims ++ "@" ++ unreserved)
+segmentNZNCParser = many1C (pctEncodedParser <|> satisfyClass (subDelims <> "@" <> unreserved))
 
 
 -------------------------------------------------------------------------------
@@ -637,22 +631,26 @@ queryParser opts = do
 -- into a key/value pair as per convention, with the value being
 -- optional. & separators need to be handled further up.
 queryItemParser :: URIParserOptions -> URIParser (ByteString, ByteString)
-queryItemParser opts = do
-  s <- A.takeWhile (upoValidQueryChar opts) `orFailWith` MalformedQuery
-  if BS.null s
+queryItemParser opts = (`orFailWith` MalformedQuery) $ do
+  let parser = if upoLaxQueryParsing opts then queryLaxItemParser else queryItemParser'
+  k <- manyC parser
+  if BS.null k
     then return (mempty, mempty)
     else do
-      let (k, vWithEquals) = BS.break (== equals) s
-      let v = BS.drop 1 vWithEquals
-      return (urlDecodeQuery k, urlDecodeQuery v)
+      A.peekWord8 >>= \case
+        Just 61 -> do
+          _ <- string "="
+          v <- manyC parser
+          return (k, v)
+        _ -> return (k, mempty)
 
 -------------------------------------------------------------------------------
-validForQuery :: Word8 -> Bool
-validForQuery = inClass ('?' : '/' : delete '&' pchar)
+queryItemParser' :: Parser ByteString
+queryItemParser' = pctEncodedParser <|> satisfyClass ('?' : '/' : (delete '=' $ delete '&' (subDelims ++ ":@" ++ unreserved)))
 
 -------------------------------------------------------------------------------
-validForQueryLax :: Word8 -> Bool
-validForQueryLax = notInClass "&#"
+queryLaxItemParser :: Parser ByteString
+queryLaxItemParser = pctEncodedParser <|> satisfyNotClass "&#="
 
 -------------------------------------------------------------------------------
 
@@ -664,9 +662,7 @@ mFragmentParser = mParse $ word8' hash *> fragmentParser
 
 -- | The final piece of a uri, e.g. #fragment, minus the #.
 fragmentParser :: URIParser ByteString
-fragmentParser = Parser' $ A.takeWhile validFragmentWord
-  where
-    validFragmentWord = inClass ('?' : '/' : pchar)
+fragmentParser = Parser' $ manyC (pcharParser <|> satisfyClass ['?', '/'])
 
 -------------------------------------------------------------------------------
 
@@ -687,8 +683,18 @@ isDigit :: Word8 -> Bool
 isDigit = inClass digit
 
 -------------------------------------------------------------------------------
-pchar :: String
-pchar = pctEncoded ++ subDelims ++ ":@" ++ unreserved
+
+pcharParser :: Parser ByteString
+pcharParser = pctEncodedParser <|> satisfyClass (subDelims ++ ":@" ++ unreserved)
+
+pcharNotParser :: Parser ByteString
+pcharNotParser = notPctEncodedParser <|> satisfyNotClass (subDelims ++ ":@" ++ unreserved)
+ where
+  notPctEncodedParser = do
+    w <- peekWord8
+    case w of
+      Just 37 -> satisfyNotClass (subDelims ++ ":@" ++ unreserved)
+      _       -> fail "not percent encoded"
 
 -------------------------------------------------------------------------------
 -- Very important!  When concatenating this to other strings to make larger
@@ -716,6 +722,18 @@ ord8 = fromIntegral . ord
 -- parser to ensure pct-encoded never exceeds 2 hexdigs after
 pctEncoded :: String
 pctEncoded = "%"
+
+pctEncodedParser :: Parser ByteString
+pctEncodedParser = string "%" *> (decode <$> A.satisfy hexDigit <*> A.satisfy hexDigit)
+ where
+  decode w1 w2 = BS.singleton $ combine (hexVal w1) (hexVal w2)
+  hexVal w
+    | 48 <= w && w <= 57  = w - 48 -- 0 - 9
+    | 65 <= w && w <= 70  = w - 55 -- A - F
+    | 97 <= w && w <= 102 = w - 87 -- a - f
+    | otherwise           = error $ "Not a hex value: " <> show w
+  combine a b = shiftL a 4 .|. b
+
 
 -------------------------------------------------------------------------------
 subDelims :: String
@@ -768,30 +786,6 @@ period = 46
 -------------------------------------------------------------------------------
 slash :: Word8
 slash = 47
-
--------------------------------------------------------------------------------
-
--- | ByteString Utilities
-
--------------------------------------------------------------------------------
-
--------------------------------------------------------------------------------
-
--- | Decoding specifically for the query string, which decodes + as
--- space. Shorthand for @urlDecode True@
-urlDecodeQuery :: ByteString -> ByteString
-urlDecodeQuery = urlDecode plusToSpace
-  where
-    plusToSpace = True
-
--------------------------------------------------------------------------------
-
--- | Decode any part of the URL besides the query, which decodes + as
--- space.
-urlDecode' :: ByteString -> ByteString
-urlDecode' = urlDecode plusToSpace
-  where
-    plusToSpace = False
 
 -------------------------------------------------------------------------------
 
@@ -913,38 +907,6 @@ fmapL :: (a -> b) -> Either a r -> Either b r
 fmapL f = either (Left . f) Right
 
 -------------------------------------------------------------------------------
-
--- | This function was extracted from the @http-types@ package. The
--- license can be found in licenses/http-types/LICENSE
-urlDecode ::
-  -- | Whether to decode '+' to ' '
-  Bool ->
-  BS.ByteString ->
-  BS.ByteString
-urlDecode replacePlus z = fst $ BS.unfoldrN (BS.length z) go z
-  where
-    go bs' =
-      case BS.uncons bs' of
-        Nothing -> Nothing
-        Just (43, ws) | replacePlus -> Just (32, ws) -- plus to space
-        Just (37, ws) -> Just $
-          fromMaybe (37, ws) $ do
-            -- percent
-            (x, xs) <- BS.uncons ws
-            x' <- hexVal x
-            (y, ys) <- BS.uncons xs
-            y' <- hexVal y
-            Just (combine x' y', ys)
-        Just (w, ws) -> Just (w, ws)
-    hexVal w
-      | 48 <= w && w <= 57 = Just $ w - 48 -- 0 - 9
-      | 65 <= w && w <= 70 = Just $ w - 55 -- A - F
-      | 97 <= w && w <= 102 = Just $ w - 87 -- a - f
-      | otherwise = Nothing
-    combine :: Word8 -> Word8 -> Word8
-    combine a b = shiftL a 4 .|. b
-
--------------------------------------------------------------------------------
 --TODO: keep an eye on perf here. seems like a good use case for a DList. the word8 list could be a set/hashset
 
 -- | Percent-encoding for URLs. Specify a list of additional
@@ -1001,4 +963,19 @@ unsnoc (RL (_ : xs)) = RL xs
 
 sequenceM :: (Semigroup a, Monoid a, Traversable t, Monad m) => t (m a) -> m a
 sequenceM = fmap (foldr (<>) mempty) . sequence
+
+satisfy' :: (Word8 -> Bool) -> Parser ByteString
+satisfy' f = BS.singleton <$> A.satisfy f
+
+many1C :: (Monoid a, Semigroup a, MonadPlus m) => m a -> m a
+many1C = fmap mconcat . A.many1
+
+manyC :: (Monoid a, Semigroup a, MonadPlus m) => m a -> m a
+manyC = fmap mconcat . A.many'
+
+satisfyClass :: String -> Parser ByteString
+satisfyClass = satisfy' . inClass
+
+satisfyNotClass :: String -> Parser ByteString
+satisfyNotClass = satisfy' . notInClass
 

--- a/src/URI/ByteString/Lens.hs
+++ b/src/URI/ByteString/Lens.hs
@@ -7,7 +7,6 @@ module URI.ByteString.Lens where
 -------------------------------------------------------------------------------
 import Control.Applicative
 import Data.ByteString (ByteString)
-import Data.Word
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
@@ -194,9 +193,9 @@ fragmentL = lens getter setter
 {-# INLINE fragmentL #-}
 
 -------------------------------------------------------------------------------
-upoValidQueryCharL :: Lens' URIParserOptions (Word8 -> Bool)
+upoValidQueryCharL :: Lens' URIParserOptions Bool
 upoValidQueryCharL =
-  lens upoValidQueryChar (\a b -> a {upoValidQueryChar = b})
+  lens upoLaxQueryParsing (\a b -> a {upoLaxQueryParsing = b})
 {-# INLINE upoValidQueryCharL #-}
 
 -------------------------------------------------------------------------------

--- a/src/URI/ByteString/QQ.hs
+++ b/src/URI/ByteString/QQ.hs
@@ -14,10 +14,11 @@ import Instances.TH.Lift ()
 import Language.Haskell.TH.Quote
 import URI.ByteString
 
+-- $setup
+-- >>> :set -XQuasiQuotes
+
 -- | Allows uri literals via QuasiQuotes language extension.
 --
--- >>> {-# LANGUAGE QuasiQuotes #-}
--- >>> stackage :: URI
 -- >>> stackage = [uri|http://stackage.org|]
 uri :: QuasiQuoter
 uri =
@@ -34,8 +35,6 @@ uri =
 
 -- | Allows relative ref literals via QuasiQuotes language extension.
 --
--- >>> {-# LANGUAGE QuasiQuotes #-}
--- >>> ref :: RelativeRef
 -- >>> ref = [relativeRef|/foo?bar=baz#quux|]
 relativeRef :: QuasiQuoter
 relativeRef =

--- a/src/URI/ByteString/Types.hs
+++ b/src/URI/ByteString/Types.hs
@@ -169,7 +169,7 @@ type RelativeRef = URIRef Relative
 -- | Options for the parser. You will probably want to use either
 -- "strictURIParserOptions" or "laxURIParserOptions"
 data URIParserOptions = URIParserOptions
-  { upoValidQueryChar :: Word8 -> Bool
+  { upoLaxQueryParsing :: Bool
   }
 
 -------------------------------------------------------------------------------

--- a/test/URI/ByteString/Generators.hs
+++ b/test/URI/ByteString/Generators.hs
@@ -95,7 +95,7 @@ genURIParserOptions = do
   cointoss <- Gen.bool
   pure $
     URIParserOptions
-      { upoValidQueryChar = const cointoss
+      { upoLaxQueryParsing = cointoss
       }
 
 genURINormalizationOptions :: Gen URINormalizationOptions

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -146,8 +146,8 @@ parseUriTests =
           "/foo"
           mempty
           (Just ""),
-      testParseFailure "http://www.example.org/foo#bar#baz" MalformedFragment,
-      testParseFailure "https://www.example.org?listParam[]=foo,bar" MalformedQuery,
+      testParseFailure "http://www.example.org/foo#bar#baz" (OtherError "endOfInput"),
+      testParseFailure "https://www.example.org?listParam[]=foo,bar" (OtherError "endOfInput"),
       testParsesLax "https://www.example.org?listParam[]=foo,bar" $
         URI
           (Scheme "https")
@@ -201,9 +201,9 @@ parseUriTests =
             (Query [])
             Nothing,
       parseTestURI strictURIParserOptions "file:///foo/%F" $
-        Left MalformedPath,
+        Left (OtherError "endOfInput"),
       parseTestURI strictURIParserOptions "file:///foo/?foo=%F" $
-        Left MalformedQuery,
+        Left (OtherError "endOfInput"),
       roundtripTestURI strictURIParserOptions "ftp://ftp.is.co.za/rfc/rfc1808.txt",
       roundtripTestURI strictURIParserOptions "http://www.ietf.org/rfc/rfc2396.txt",
       roundtripTestURI strictURIParserOptions "mailto:John.Doe@example.com",
@@ -219,7 +219,7 @@ parseUriTests =
             (Query [])
             Nothing,
       parseTestRelativeRef strictURIParserOptions "this:that/thap/sub?1=2" $
-        Left $ MalformedPath,
+        Left (OtherError "endOfInput"),
       parseTestRelativeRef strictURIParserOptions "./this:that/thap/sub?1=2" $
         Right $
           RelativeRef

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -171,6 +171,14 @@ parseUriTests =
             "/."
             (Query [])
             Nothing,
+      parseTestURI strictURIParserOptions "file:c:/foo" $
+        Right $
+          URI
+            (Scheme "file")
+            Nothing
+            "c:/foo"
+            (Query [])
+            Nothing,
       roundtripTestURI strictURIParserOptions "ftp://ftp.is.co.za/rfc/rfc1808.txt",
       roundtripTestURI strictURIParserOptions "http://www.ietf.org/rfc/rfc2396.txt",
       roundtripTestURI strictURIParserOptions "mailto:John.Doe@example.com",

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -146,8 +146,8 @@ parseUriTests =
           "/foo"
           mempty
           (Just ""),
-      testParseFailure "http://www.example.org/foo#bar#baz" (OtherError "endOfInput"),
-      testParseFailure "https://www.example.org?listParam[]=foo,bar" (OtherError "endOfInput"),
+      testParseFailure "http://www.example.org/foo#bar#baz" MalformedFragment,
+      testParseFailure "https://www.example.org?listParam[]=foo,bar" MalformedQuery,
       testParsesLax "https://www.example.org?listParam[]=foo,bar" $
         URI
           (Scheme "https")
@@ -201,9 +201,9 @@ parseUriTests =
             (Query [])
             Nothing,
       parseTestURI strictURIParserOptions "file:///foo/%F" $
-        Left (OtherError "endOfInput"),
+        Left MalformedPath,
       parseTestURI strictURIParserOptions "file:///foo/?foo=%F" $
-        Left (OtherError "endOfInput"),
+        Left MalformedQuery,
       roundtripTestURI strictURIParserOptions "ftp://ftp.is.co.za/rfc/rfc1808.txt",
       roundtripTestURI strictURIParserOptions "http://www.ietf.org/rfc/rfc2396.txt",
       roundtripTestURI strictURIParserOptions "mailto:John.Doe@example.com",
@@ -219,7 +219,7 @@ parseUriTests =
             (Query [])
             Nothing,
       parseTestRelativeRef strictURIParserOptions "this:that/thap/sub?1=2" $
-        Left (OtherError "endOfInput"),
+        Left $ MalformedPath,
       parseTestRelativeRef strictURIParserOptions "./this:that/thap/sub?1=2" $
         Right $
           RelativeRef

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -80,8 +80,29 @@ parseUriTests =
           (Scheme "https")
           (Just (Authority (Just (UserInfo "user" "pass:wo rd")) (Host "www.example.org") Nothing))
           ""
-          (Query [("foo", "bar"), ("foo", "baz quux")])
+          (Query [("foo", "bar"), ("foo", "baz+quux")])
           (Just "frag"),
+      testParses "https://user@www.example.org" $
+        URI
+          (Scheme "https")
+          (Just (Authority (Just (UserInfo "user" "")) (Host "www.example.org") Nothing))
+          ""
+          (Query [])
+          Nothing,
+      testParses "https://@www.example.org" $
+        URI
+          (Scheme "https")
+          (Just (Authority (Just (UserInfo "" "")) (Host "www.example.org") Nothing))
+          ""
+          (Query [])
+          Nothing,
+      testParses "https://::@www.example.org" $
+        URI
+          (Scheme "https")
+          (Just (Authority (Just (UserInfo "" ":")) (Host "www.example.org") Nothing))
+          ""
+          (Query [])
+          Nothing,
       -- trailing &
       testParses "http://www.example.org?foo=bar&" $
         URI
@@ -179,6 +200,10 @@ parseUriTests =
             "c:/foo"
             (Query [])
             Nothing,
+      parseTestURI strictURIParserOptions "file:///foo/%F" $
+        Left MalformedPath,
+      parseTestURI strictURIParserOptions "file:///foo/?foo=%F" $
+        Left MalformedQuery,
       roundtripTestURI strictURIParserOptions "ftp://ftp.is.co.za/rfc/rfc1808.txt",
       roundtripTestURI strictURIParserOptions "http://www.ietf.org/rfc/rfc2396.txt",
       roundtripTestURI strictURIParserOptions "mailto:John.Doe@example.com",


### PR DESCRIPTION
We untagle the relativeRef and uriParser here. They are weirdly intertwined, although they have different BNFs.

We also specify the 'hierPartParser' and the 'rrPathParser' (now named 'relativePartParser') more closely according to the spec, which also fixes #63.

Further, we don't run urlDecodeQuery over the path components, just the query components. "tel:+1-816-555-1212" was parsed correctly out of sheer luck, because the 'rrPathParser' didn't run 'urlDecodeQuery' over the first segment, only the subsequent ones. We now use urlDecode' instead for path components.

----

The second commit makes the `pchar` or `pct-encoded` more spec conformant: we now decode consistently during parsing and don't need a two-pass strategy. For that we have to be careful to not use any `BS.break` etc. after parsing, which is the case now.

I also removed the `+` to ` ` conversion completely, because it has nothing to do with the RFC3986 spec. An end user can post-process the query parameters accordingly, if they want. These are breaking changes. The first commit is not.

----

It is quite possible that these changes impact performance negatively, but imo, correctness here is much more important than speed.