### PR TITLE
Decoding issues

### DIFF
--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -69,7 +69,16 @@ laxURIParserOptions =
 
 -- | All normalization options disabled
 noNormalization :: URINormalizationOptions
-noNormalization = URINormalizationOptions False False False False False False False httpDefaultPorts
+noNormalization = URINormalizationOptions
+  { unoDowncaseScheme = False,
+    unoDowncaseHost = False,
+    unoDropDefPort = False,
+    unoSlashEmptyPath = False,
+    unoDropExtraSlashes = False,
+    unoSortParameters = False,
+    unoRemoveDotSegments = False,
+    unoDefaultPorts = httpDefaultPorts
+  }
 
 -------------------------------------------------------------------------------
 
@@ -117,7 +126,16 @@ httpNormalization =
 
 -- | All options enabled
 aggressiveNormalization :: URINormalizationOptions
-aggressiveNormalization = URINormalizationOptions True True True True True True True httpDefaultPorts
+aggressiveNormalization = URINormalizationOptions
+  { unoDowncaseScheme = True,
+    unoDowncaseHost = True,
+    unoDropDefPort = True,
+    unoSlashEmptyPath = True,
+    unoDropExtraSlashes = True,
+    unoSortParameters = True,
+    unoRemoveDotSegments = True,
+    unoDefaultPorts = httpDefaultPorts
+  }
 
 -------------------------------------------------------------------------------
 

--- a/src/URI/ByteString/Internal.hs
+++ b/src/URI/ByteString/Internal.hs
@@ -303,7 +303,7 @@ serializeQuery' opts = BB.toByteString . serializeQuery opts
 
 -------------------------------------------------------------------------------
 serializeFragment :: Maybe ByteString -> Builder
-serializeFragment = maybe mempty (\s -> c8 '#' <> bs s)
+serializeFragment = maybe mempty (\s -> c8 '#' <> urlEncodeQuery s)
 
 serializeFragment' :: Maybe ByteString -> ByteString
 serializeFragment' = BB.toByteString . serializeFragment

--- a/test/URI/ByteStringTests.hs
+++ b/test/URI/ByteStringTests.hs
@@ -210,6 +210,11 @@ parseUriTests =
       roundtripTestURI strictURIParserOptions "news:comp.infosystems.www.servers.unix",
       roundtripTestURI strictURIParserOptions "tel:+1-816-555-1212",
       roundtripTestURI strictURIParserOptions "telnet://192.0.2.16:80/",
+      -- percent encoding in queries and fragments
+      roundtripTestURI strictURIParserOptions "http://example.com/foo#bar%20baz",
+      roundtripTestURI strictURIParserOptions "http://example.com/foo?bar%20baz=quux",
+      roundtripTestURI strictURIParserOptions "http://example.com/foo?bar=baz%20quux",
+      roundtripTestURI strictURIParserOptions "http://example.com/foo?bar=baz%20quux#bar%20baz",
       -- RFC 3986, Section 4.2
       parseTestRelativeRef strictURIParserOptions "verysimple" $
         Right $


### PR DESCRIPTION
We noticed in another codebase that #64 pushed percent decoding into the fragment parser but there was no corresponding percent encoder in the serializer. The result is that if you parse a URI with a percent-encoded fragment and then serialize it, that serialized version will not parse properly because it will likely contain characters that should be encoded.

@hasufell Could you please look this over?